### PR TITLE
Add preview after signing from chainweaver/zelcore

### DIFF
--- a/frontend/src/containers/SwapContainer.js
+++ b/frontend/src/containers/SwapContainer.js
@@ -276,11 +276,16 @@ const SwapContainer = () => {
                 setLoading(false)
               }
             } else {
-              pact.swapWallet(
+              const res = await pact.swapWallet(
                 { amount: fromValues.amount, address: fromValues.address, coin: fromValues.coin },
                 { amount: toValues.amount, address: toValues.address, coin: toValues.coin },
                 (fromNote === "(estimated)" ? false : true)
               )
+              setShowTxModal(true)
+              if (res?.result?.status === 'success') {
+                setFromValues({ amount: '', balance: '', coin: '', address: '', precision: 0 });
+                setToValues({ amount: '', balance: '', coin: '', address: '', precision: 0 })
+              }
               setLoading(false)
             }
 

--- a/frontend/src/containers/liquidity/LiquidityContainer.js
+++ b/frontend/src/containers/liquidity/LiquidityContainer.js
@@ -228,8 +228,9 @@ const LiquidityContainer = (props) => {
           }
         } else {
           setLoading(true)
-          pact.addLiquidityWallet(pact.tokenData[fromValues.coin], pact.tokenData[toValues.coin], fromValues.amount, toValues.amount);
           setShowReview(false)
+          const res = await pact.addLiquidityWallet(pact.tokenData[fromValues.coin], pact.tokenData[toValues.coin], fromValues.amount, toValues.amount);
+          setShowTxModal(true)
           setLoading(false)
           setFromValues({account: null, guard: null, balance: null, amount: '', coin: ""});
           setToValues({account: null, guard: null, balance: null, amount: '', coin: ""})

--- a/frontend/src/containers/liquidity/RemoveLiquidityContainer.js
+++ b/frontend/src/containers/liquidity/RemoveLiquidityContainer.js
@@ -107,7 +107,10 @@ const RemoveLiquidityContainer = (props) => {
                 setLoading(false)
               }
             } else {
-              pact.removeLiquidityWallet(pact.tokenData[token0].code, pact.tokenData[token1].code, reduceBalance(pooled, pact.PRECISION));
+              setLoading(true)
+              const res = await pact.removeLiquidityWallet(pact.tokenData[token0].code, pact.tokenData[token1].code, reduceBalance(pooled, pact.PRECISION));
+              setShowTxModal(true)
+              setLoading(false)
             }
           }
         }>

--- a/frontend/src/contexts/PactContext.js
+++ b/frontend/src/contexts/PactContext.js
@@ -404,13 +404,12 @@ export const PactProvider = (props) => {
       //close alert programmatically
       swal.close()
       setWalletSuccess(true)
-      const res = await Pact.wallet.sendSigned(cmd, network);
-      //this is a small hack to get the polling header widget to work
-      setLocalRes({ reqKey: res.requestKeys[0] })
-      setPolling(true)
-      pollingNotif(res.requestKeys[0]);
-      await listen(res.requestKeys[0]);
-      setPolling(false)
+      //set signedtx
+      setCmd(cmd);
+      let data = await fetch(`${network}/api/v1/local`, mkReq(cmd))
+      data = await parseRes(data);
+      setLocalRes(data);
+      return data;
     } catch (e) {
       //wallet error alert
       if (e.message.includes('Failed to fetch')) walletError()
@@ -507,13 +506,18 @@ export const PactProvider = (props) => {
       //close alert programmatically
       swal.close()
       setWalletSuccess(true)
-      const res = await Pact.wallet.sendSigned(cmd, network);
-      //this is a small hack to get the polling header widget to work
-      setLocalRes({ reqKey: res.requestKeys[0] })
-      setPolling(true)
-      pollingNotif(res.requestKeys[0]);
-      await listen(res.requestKeys[0]);
-      setPolling(false)
+      setCmd(cmd);
+      let data = await fetch(`${network}/api/v1/local`, mkReq(cmd))
+      data = await parseRes(data);
+      setLocalRes(data);
+      return data;
+      // const res = await Pact.wallet.sendSigned(cmd, network);
+      // //this is a small hack to get the polling header widget to work
+      // setLocalRes({ reqKey: res.requestKeys[0] })
+      // setPolling(true)
+      // pollingNotif(res.requestKeys[0]);
+      // await listen(res.requestKeys[0]);
+      // setPolling(false)
     } catch (e) {
       //wallet error alert
       if (e.message.includes('Failed to fetch')) walletError()

--- a/frontend/src/contexts/PactContext.js
+++ b/frontend/src/contexts/PactContext.js
@@ -64,7 +64,6 @@ export const PactProvider = (props) => {
   const [registered, setRegistered] = useState(false);
   const [ttl, setTtl] = useState((savedTtl ? savedTtl : 600));
   const [balances, setBalances] = useState(false);
-  const [signedTx, setSignedTx] = useState({});
 
   //TO FIX, not working when multiple toasts are there
   const toastId = React.useRef(null)
@@ -511,13 +510,6 @@ export const PactProvider = (props) => {
       data = await parseRes(data);
       setLocalRes(data);
       return data;
-      // const res = await Pact.wallet.sendSigned(cmd, network);
-      // //this is a small hack to get the polling header widget to work
-      // setLocalRes({ reqKey: res.requestKeys[0] })
-      // setPolling(true)
-      // pollingNotif(res.requestKeys[0]);
-      // await listen(res.requestKeys[0]);
-      // setPolling(false)
     } catch (e) {
       //wallet error alert
       if (e.message.includes('Failed to fetch')) walletError()
@@ -913,14 +905,6 @@ export const PactProvider = (props) => {
       data = await parseRes(data);
       setLocalRes(data);
       return data;
-      // const res = await Pact.wallet.sendSigned(cmd, network);
-      // console.log(res)
-      // //this is a small hack to get the polling header widget to work
-      // setLocalRes({ reqKey: res.requestKeys[0] })
-      // setPolling(true)
-      // pollingNotif(res.requestKeys[0]);
-      // await listen(res.requestKeys[0]);
-      // setPolling(false)
     } catch (e) {
       //wallet error alert
       if (e.message.includes('Failed to fetch')) walletError()
@@ -939,7 +923,6 @@ export const PactProvider = (props) => {
       } else {
         data = await Pact.wallet.sendSigned(cmd, network)
       }
-      console.log(data)
       pollingNotif(data.requestKeys[0]);
       await listen(data.requestKeys[0]);
       setPolling(false)
@@ -1386,8 +1369,7 @@ var parseRes = async function (raw) {
         kpennyReserveLocal,
         kpennyReserveWallet,
         kpennyRedeemWallet,
-        kpennyRedeemLocal,
-        signedTx
+        kpennyRedeemLocal
       }}
     >
       {props.children}

--- a/frontend/src/contexts/PactContext.js
+++ b/frontend/src/contexts/PactContext.js
@@ -1105,7 +1105,6 @@ const kpennyReserveLocal = async (amtKda) => {
     console.log(cmd)
     setCmd(cmd);
     let data = await Pact.fetch.local(cmd, network);
-    console.log(data)
     setLocalRes(data);
     return data;
   } catch (e) {


### PR DESCRIPTION
Instead of sending the signed command from wallet, show preview modal with the signed cmd and have users click the send button. 
Closes #108 