### PR TITLE
Update KdaModal.js

### DIFF
--- a/relay-fe/src/wallet/modals/kdaModal/KdaModal.js
+++ b/relay-fe/src/wallet/modals/kdaModal/KdaModal.js
@@ -144,7 +144,7 @@ export default function Account(props) {
               <></>
             ) : (
               <Header>
-                <span style={{ color: "red", fontSize: 24 }}>Account Does Not Exist</span>
+                <span style={{ color: "red", fontSize: 24 }}>Please add some funds to a wallet on Chain 2 to continue. Read more about how to use the relay <a href="https://medium.com/kadena-io/chain-relay-bonding-launch-3ee23bc95d1d">here</a></span>
               </Header>
             )}
             <div style={{ opacity: pact?.account?.account ? 1 : 0.3, marginTop: 30, marginBottom: 30 }}>


### PR DESCRIPTION
On line 147, the error message previously said "Account does not exist". This was confusing to me, technically to fix the error one has to send funds to a wallet on chain 2. So this fork proposes changing the wording of this message to: 

<span style={{ color: "red", fontSize: 24 }}>Please add some funds to a wallet on Chain 2 to continue. Read more about how to use the relay <a target="_blank" href="https://medium.com/kadena-io/chain-relay-bonding-launch-3ee23bc95d1d">here</a></span>