### PR TITLE
Formal verification for all table writes

### DIFF
--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           mkdir bin
           cd bin
-          wget https://github.com/kadena-io/pact/releases/download/v4.0.1/pact-4.0.1-linux.zip
+          wget https://github.com/kadena-io/pact/releases/download/v4.1/pact-4.1-linux-18.04.zip
           unzip "pact*.zip"
           chmod +x pact
           cd ..

--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -32,7 +32,12 @@ jobs:
           unzip "pact*.zip"
           chmod +x pact
           cd ..
-
+      - name: Install z3 (ubuntu-18.04)
+        uses: pavpanchekha/setup-z3@0.2.0
+        with:
+          version: "4.8.10"
+          architecture: "x64"
+          distribution: "ubuntu-18.04"
       - name: pact/exchange.repl
         run: |
           bin/pact -t pact/exchange.repl > out.log 2>&1

--- a/pact/exchange.pact
+++ b/pact/exchange.pact
@@ -15,7 +15,7 @@
      (when (row-written pairs k)
        (row-enforced pairs 'guard k)))
     { 'except:
-      [ create-pair      ;; prop-admin-guard
+      [ create-pair      ;; unguarded (insert semantics)
         add-liquidity    ;; prop-increase-liquidity
         remove-liquidity ;; prop-decrease-liquidity
         swap-exact-in    ;; prop-increase-liquidity
@@ -26,15 +26,6 @@
         update-reserves  ;; PRIVATE
       ] } )
 
-
-   ;; prop-admin-guard
-   (property
-    (forall (k:string)
-     (when (row-written pairs k)
-       (authorized-by 'swap-ns-admin)))
-    { 'only:
-      [ create-pair
-      ] } )
 
    ;;prop-increase-liquidity
    ;;computes constant-product variance

--- a/pact/exchange.pact
+++ b/pact/exchange.pact
@@ -343,6 +343,7 @@
       ( (rpath (reverse path))
         (path-len (length path))
         (pz (get-pair (at 0 rpath) (at 1 rpath)))
+        (e:[module{fungible-v2}] [])
         (allocs
           (fold (compute-in)
             [ { 'token-out: (at 1 rpath)
@@ -351,7 +352,7 @@
               , 'in: amountOut
               , 'idx: path-len
               , 'pair: pz
-              , 'path: []
+              , 'path: e
               }]
             (drop 1 rpath)))
         (allocs1 ;; drop dummy at end, prepend dummy for initial transfer
@@ -551,7 +552,7 @@
           })))
     )
 
-  (defun get-pair-key
+  (defun get-pair-key:string
     ( tokenA:module{fungible-v2}
       tokenB:module{fungible-v2}
     )
@@ -603,7 +604,7 @@
     (hash (+ hint (+ key (format "{}" [(at 'block-time (chain-data))]))))
   )
 
-  (defun truncate (token:module{fungible-v2} amount:decimal)
+  (defun truncate:decimal (token:module{fungible-v2} amount:decimal)
     (floor amount (token::precision))
   )
 

--- a/pact/exchange.repl
+++ b/pact/exchange.repl
@@ -19,8 +19,15 @@
 (load "ns.pact")
 (load "fungible-util.pact")
 (load "tokens.pact")
+
+(verify "swap.tokens")
+
 (load "swap-callable.pact")
 (load "exchange.pact")
+
+(env-dynref fungible-v2 coin)
+(env-dynref swap.swap-callable-v1 swap.noop-callable)
+(verify "swap.exchange")
 
 (env-data { 'ns: "swap", 'upgrade: false })
 (load "test/ABC.pact")

--- a/pact/relay/relay.pact
+++ b/pact/relay/relay.pact
@@ -2,6 +2,30 @@
 (namespace (read-msg 'ns))
 (module relay GOVERNANCE
 
+  @model [
+
+    ;; prop-write-bonder-cap
+    ;; enumerates all db writes
+    (property
+     (forall (hk:string pk:string)
+      (when (or (row-written heights hk)
+                (row-written proposals pk))
+        bonder-cap-acquired))
+     { 'except:           ;; all await bonder cap feature
+       [ propose          ;;
+         endorse          ;;
+         denounce         ;;
+         endorse-denounce ;;
+       ] } )
+
+    (defproperty bonder-cap-acquired ()
+      ;; upcoming property to enforce BONDER acquire
+      ;; using trivial prop for now
+      (= 1 1))
+
+  ]
+
+
   (use util.guards)
 
   (defcap GOVERNANCE ()

--- a/pact/relay/relay.repl
+++ b/pact/relay/relay.repl
@@ -24,7 +24,11 @@
 (define-keyset 'relay-ns-admin)
 (env-keys ['admin])
 (load "pool.pact")
+
+(env-dynref fungible-v2 coin)
+(verify "test.pool")
 (load "relay.pact")
+(verify "test.relay")
 (env-data { 'Bob: ["bob"], 'Alice:["alice"]
           , 'Carol:["carol"], 'Admin:["admin"], 'Pam:["pam"]})
 (test-capability (coin.COINBASE))


### PR DESCRIPTION
This requires the upcoming Pact 4.1 release to operate, but it demonstrates a reasonably complete model for guarding database writes. Coverage will include relay/pool, and exchange/tokens.

NOTE: CI will fail because of needing Pact 4.1 build. 