### PR TITLE
Update actives on bond servicing

### DIFF
--- a/pact/relay/pool.pact
+++ b/pact/relay/pool.pact
@@ -339,6 +339,7 @@
         , 'rate:= rate
         , 'terminated:= terminated
         }
+        (update-actives pool)
         (enforce (not terminated) "Terminated")
         (with-read pools pool
           { 'token:= token:module{fungible-v2}
@@ -388,6 +389,7 @@
         , 'terminated:= terminated
         , 'renewed:= renewed
         }
+        (update-actives pool)
         (enforce (not terminated) "Terminated")
         (with-read pools pool
           { 'token:= token:module{fungible-v2}
@@ -516,7 +518,6 @@
      )
     " Pick random selection of active bonders, without BONDERS, from POOL. \
     \ Count is if ENDORSE endorsers otherwise denouncers from pool config."
-    (update-actives pool)
     (with-read pools pool
       { 'active:=active
       , 'endorsers:= endorsers

--- a/pact/relay/relay.repl
+++ b/pact/relay/relay.repl
@@ -402,6 +402,7 @@
   ["Bob:2021-01-01" "Alice:2021-01-01" "Bob:2021-01-02" "Alice:2021-01-02"
    "Bob:2021-01-03" "Alice:2021-01-03" "Carol:2021-01-03"]
   (at 'active (test.pool.get-pool test.relay.POOL)))
+(test.pool.update-actives test.relay.POOL)
 (expect-failure "Alice 2 propose but not enough active bonders"
   "not enough active bonders"
   (test.relay.propose (read-msg 'header) "Alice:2021-01-02"))
@@ -670,6 +671,7 @@
 
 (env-chain-data
   { 'block-time: (parse-time "%F" "2021-01-31")} ) ;; eliminates Pam 1
+(test.pool.update-actives test.relay.POOL)
 (expect-failure
   "Denounce requires 7 fresh bonders"
   "not enough active bonders"


### PR DESCRIPTION
Move active-list maintenance out of `pick-actives` into `renew` and `unbond`